### PR TITLE
Add debug options for validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   "scripts": {
     "start": "node lib/main.js",
     "build": "tsc -p tsconfig.build.json",
+    "build:debug": "tsc -p tsconfig.build.json --sourceMap true --removeComments false",
+    "debug:ajv": "node lib/debug-ajv.js",
     "test": "npm run build && jest",
     "format": "prettier --write '**/*.{ts,js,json}'"
   },

--- a/src/debug-ajv.ts
+++ b/src/debug-ajv.ts
@@ -1,0 +1,71 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import Ajv from 'ajv';
+import betterAjvErrors from 'better-ajv-errors';
+const chalk = require('chalk');
+
+// Setup AJV with better debugging
+const ajv = new Ajv({
+    allErrors: true,
+    verbose: true,
+    jsonPointers: true,
+    errorDataPath: 'property',
+});
+
+function debugValidation(schemaPath: string, jsonPath: string) {
+    try {
+        // Load schema and JSON
+        const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
+        const data = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+
+        console.log(chalk.blue(`\n🔍 Validating: ${jsonPath}`));
+        console.log(chalk.blue(`📋 Schema: ${schemaPath}\n`));
+
+        // Compile schema
+        const validate = ajv.compile(schema);
+
+        // Validate
+        const valid = validate(data);
+
+        if (valid) {
+            console.log(chalk.green('✅ Validation passed!'));
+        } else {
+            console.log(chalk.red('❌ Validation failed!\n'));
+
+            // Show better errors
+            const output = betterAjvErrors(schema, data, validate.errors, {
+                format: 'cli',
+                indent: 2,
+            });
+
+            console.log(output);
+
+            // Also show raw AJV errors for debugging
+            console.log(chalk.yellow('\n📝 Raw AJV Errors:'));
+            console.log(JSON.stringify(validate.errors, null, 2));
+        }
+    } catch (error) {
+        console.error(chalk.red('💥 Error:'), (error as any).message);
+    }
+}
+
+// Usage examples - modify these paths as needed
+const args = process.argv.slice(2);
+if (args.length >= 2) {
+    debugValidation(args[0], args[1]);
+} else {
+    // Try to use environment variables like the main script
+    const schemaPath = process.env.INPUT_SCHEMA || process.env.SCHEMA;
+    const jsonPath = process.env.INPUT_JSONS || process.env.JSONS;
+    const workspace = process.env.GITHUB_WORKSPACE || '.';
+
+    if (schemaPath && jsonPath) {
+        const fullSchemaPath = path.join(workspace, schemaPath);
+        const fullJsonPath = path.join(workspace, jsonPath);
+        debugValidation(fullSchemaPath, fullJsonPath);
+    } else {
+        console.log(chalk.yellow('Usage: npm run debug:ajv <schema-path> <json-path>'));
+        console.log(chalk.yellow('Example: npm run debug:ajv boards/schema.json boards/example/definition.json'));
+        console.log(chalk.yellow('Or set environment variables: INPUT_SCHEMA, INPUT_JSONS, GITHUB_WORKSPACE'));
+    }
+}


### PR DESCRIPTION
Found when adding exported config for the magtag that the labels and visualisations properties (UI customisation) are not supported and cause insane validation errors (talking about isServo at the opening bracket of object with viz prop).

This adds a debug build, and a debug file for AJV (Another JSON Validator), so proper validation errors can be understood.

Run `npm run build:debug` to include sourcemaps and comments in typescript output.

Then use `$env:INPUT_SCHEMA="boards\magic_schema.json"; $ENV:INPUT_JSONS="boards\magtag\magic.json"; $ENV:GITHUB_WORKSPACE=".."; npm run debug:ajv` to validate a specific schema issue.


### Original validation error reported (incorrectly):
<img width="480" height="430" alt="image" src="https://github.com/user-attachments/assets/1404081e-baae-4fd3-b3cb-7e84e3507dae" />


### Correct validation problem with schema when run through debug validation:
<img width="902" height="239" alt="image" src="https://github.com/user-attachments/assets/b5edf6ca-f187-44e0-ac8f-5dcc810b0a48" />



Co-Authored with Claude Sonnet 4.